### PR TITLE
api: new lmp build names to trigger merge

### DIFF
--- a/conductor/api/views.py
+++ b/conductor/api/views.py
@@ -262,7 +262,7 @@ def process_lmp_build(request):
             logger.warning("status not set to PASSED")
             return HttpResponse("OK")
         # check if the build has trigger_name "build-release"
-        if request_body_json.get("trigger_name") in ["build-release", "build-release-stable"]:
+        if request_body_json.get("trigger_name") in ["build-release", "build-release-stable", "build-lts", "build-main", "build-eol"]:
             merge_lmp_manifest.delay()
             return HttpResponse("Created", status=201)
         if request_body_json.get("trigger_name") in ["Code Review"]:


### PR DESCRIPTION
After v95 LmP release build names were updated to support multi branch development model. New build names are:
 - build-main
 - build-lts
 - build-eol

This patch adds manifest merge triggers based on these build names. Manifest URL is still kept in each project.